### PR TITLE
[Fix] update directory path in add handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const remove = async (name, sysPath) => {
 
 const addThemeHandler = (argv) => {
   const themeName = argv.name;
-  const themePagesDir = path.join(__dirname, `themes`, `${themeName}`);
+  const themePagesDir = path.join(`./`, `themes`, `${themeName}`);
 
   fs.ensureDir(themePagesDir)
     .then(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-jay",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-jay",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Theme manager for gatsby-theme-kit",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Themes are now added to the themes folder in the current working
directory and not in the modules directory. The last commit missed
this feature in the update.